### PR TITLE
Fix issue where modal took up 100% of the window height and modal did…

### DIFF
--- a/.changeset/famous-wasps-try.md
+++ b/.changeset/famous-wasps-try.md
@@ -2,4 +2,7 @@
 "@3squared/forge-ui-3": patch
 ---
 
-Fix issue where Modal wouldn't maximise correctly and close/maximise button styling
+- Fix issue where Modal would take up 100% of the screen height on open.
+- Fix issue where Modal wouldn't expand outwards when maximised.
+- Fix styling issues for Close and Maximise buttons.
+- Fix issue where Modal wouldn't position correctly when setting the position prop to anything other than top, center or bottom.

--- a/.changeset/famous-wasps-try.md
+++ b/.changeset/famous-wasps-try.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui-3": patch
+---
+
+Fix issue where Modal wouldn't maximise correctly and close/maximise button styling

--- a/packages/ui/src/Bootstrap_PT.ts
+++ b/packages/ui/src/Bootstrap_PT.ts
@@ -466,9 +466,6 @@ export default {
       })
   },
   dialog: {
-    root: () => ({
-      class: ['modal modal-dialog modal-content vw-100']
-    }),
     header: () => ({
       class: ['modal-header']
     }),
@@ -484,8 +481,18 @@ export default {
     headerIcons: () => ({
       class: ['ms-auto']
     }),
+    icons: 'd-flex w-100',
+    closeButton: ({ props }) => ({
+      class: [
+        'btn',
+        {
+          'ms-auto': !props.maximizable
+        }
+      ]
+    }),
     maximizableButton: ({ props }) => ({
       class: [
+        'btn ms-auto',
         {
           "me-2": props.closable
         }

--- a/packages/ui/src/Bootstrap_PT.ts
+++ b/packages/ui/src/Bootstrap_PT.ts
@@ -481,7 +481,7 @@ export default {
     headerIcons: () => ({
       class: ['ms-auto']
     }),
-    icons: 'd-flex w-100',
+    icons: 'd-flex ms-auto',
     closeButton: ({ props }) => ({
       class: [
         'btn',

--- a/packages/ui/src/components/ForgeModal.vue
+++ b/packages/ui/src/components/ForgeModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Dialog v-bind="props">
+  <Dialog v-bind="props" @maximize="fullscreen = true" @unmaximize="fullscreen = false" :pt="pt">
     <template #closeicon>
       <Icon data-cy="close-icon" icon="bi:x-lg" width="21" height="21" @click="closeModal"/>
     </template>
@@ -31,10 +31,10 @@
 
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
-import { DialogProps } from "primevue/dialog";
+import { DialogPassThroughOptions, DialogProps } from "primevue/dialog";
 import ForgeAlert from "./ForgeAlert.vue";
 import ForgeLoader from "./ForgeLoader.vue";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { parseError } from "../helpers";
 
 interface ModalError {
@@ -50,7 +50,8 @@ export interface ForgeModalProps extends DialogProps {
   onConfirm?: Function | null,
 }
 
-const emit = defineEmits(['update:visible'])
+const visible = defineModel<boolean>('visible', { required: true })
+const fullscreen = ref<boolean>(false)
 
 const props = withDefaults(defineProps<ForgeModalProps>(), {
   modal: true,
@@ -73,7 +74,7 @@ const error = ref<ModalError>({
 })
 
 const closeModal = () => {
-  emit("update:visible", false)
+  visible.value = false
 }
 
 const success = async () => {
@@ -96,4 +97,13 @@ const success = async () => {
     loading.value = false;
   }
 }
+
+const pt = computed<DialogPassThroughOptions>(() => ({
+  root: [
+    'modal modal-dialog modal-content h-auto',
+    {
+      'vw-100 mw-100 vh-100': fullscreen.value
+    }
+  ]
+}))
 </script>

--- a/packages/ui/src/components/ForgeModal.vue
+++ b/packages/ui/src/components/ForgeModal.vue
@@ -102,7 +102,7 @@ const pt = computed<DialogPassThroughOptions>(() => ({
   root: [
     'modal modal-dialog modal-content h-auto',
     {
-      'vw-100 mw-100 vh-100': fullscreen.value
+      'mw-100 vh-100 vw-100 top-0 start-0': fullscreen.value
     }
   ]
 }))

--- a/packages/ui/src/components/ForgeModal.vue
+++ b/packages/ui/src/components/ForgeModal.vue
@@ -100,7 +100,7 @@ const success = async () => {
 
 const pt = computed<DialogPassThroughOptions>(() => ({
   root: [
-    'modal modal-dialog modal-content h-auto',
+    'modal modal-dialog modal-content h-auto m-0',
     {
       'mw-100 vh-100 vw-100 top-0 start-0': fullscreen.value
     }

--- a/packages/ui/src/components/ForgeModal.vue
+++ b/packages/ui/src/components/ForgeModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Dialog v-bind="props" @maximize="fullscreen = true" @unmaximize="fullscreen = false" :pt="pt">
+  <Dialog v-bind="props" @maximize="maximise" @unmaximize="minimise" :pt="pt">
     <template #closeicon>
       <Icon data-cy="close-icon" icon="bi:x-lg" width="21" height="21" @click="closeModal"/>
     </template>
@@ -72,6 +72,14 @@ const error = ref<ModalError>({
   header: "",
   message: []
 })
+
+const minimise = () => {
+  fullscreen.value = false
+}
+
+const maximise = () => {
+  fullscreen.value = true
+}
 
 const closeModal = () => {
   visible.value = false

--- a/packages/ui/tests/component/dialog/dialog.cy.ts
+++ b/packages/ui/tests/component/dialog/dialog.cy.ts
@@ -3,6 +3,9 @@ import DialogWrapper from "./DialogWrapper.vue";
 import { ForgeModalProps } from "../../../src/components/ForgeModal.vue";
 
 const modalId = "modal"
+const dialog = '[data-pc-name="dialog"]'
+const maximiseButton = '[data-pc-section="maximizablebutton"]'
+const closeButton = '[data-pc-section="closebutton"]'
 
 function mountDialog(props : ForgeModalProps) {
   cy.mount(DialogWrapper, {
@@ -48,11 +51,21 @@ describe('<Dialog />', () => {
   it("Displays close icon in the top right corner", () => {
     // Arrange
     const iconClass = "iconify iconify--bi"
+    const buttonClass = 'btn'
+    const positionClass = 'd-flex ms-auto'
     
     // Act
     mountDialog({ closable: true })
 
     // Assert
+    cy.get(`[data-pc-section="icons"]`)
+      .should('have.class', positionClass)
+
+    cy.get(closeButton)
+      .should('exist')
+      .and('be.visible')
+      .and('have.class', buttonClass)
+    
     cy.get(`[data-cy="close-icon"]`)
       .should('exist')
       .and('be.visible')
@@ -62,15 +75,41 @@ describe('<Dialog />', () => {
   it("Displays maximisable icon when maximizable prop is true", () => {
     // Arrange
     const iconClass = "iconify iconify--bi"
-
+    const buttonClass = 'btn'
+    const positionClass = 'd-flex ms-auto'
+    
     // Act
     mountDialog({ maximizable: true })
 
     // Assert
+    cy.get(`[data-pc-section="icons"]`)
+      .should('have.class', positionClass)
+    
+    cy.get(maximiseButton)
+      .should('exist')
+      .and('be.visible')
+      .and('have.class', buttonClass)
+    
     cy.get(`[data-cy="maximisable-icon"]`)
       .should('exist')
       .and('be.visible')
       .and('have.class', iconClass)
+  })
+  
+  it("Should take up the entire screen when maximised", () => {
+    // Arrange
+    const fullscreenClass = 'mw-100 vh-100 vw-100 top-0 start-0'
+    
+    // Act
+    mountDialog({ maximizable: true })
+    
+    cy.get(maximiseButton).click()
+    
+    // Assert
+    cy.get(dialog)
+      .should('exist')
+      .and('be.visible')
+      .and('have.class', fullscreenClass)
   })
   
   it('Displays custom title which is passed in via props', () => {

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -31,6 +31,8 @@
   },
   "include": [
     "src",
+    "**/*.cy.ts",
+    "cypress/support/component.ts",
     "index.ts"
   ],
   "exclude": [


### PR DESCRIPTION
- Fix issue where Modal would take up 100% of the screen height on open.
- Fix issue where Modal wouldn't expand outwards when maximised.
- Fix styling issues for Close and Maximise buttons.
- Fix issue where Modal wouldn't position correctly when setting the position prop to anything other than top, center or bottom.
