### PR TITLE
Fix non customisable brand colours

### DIFF
--- a/.changeset/four-coats-battle.md
+++ b/.changeset/four-coats-battle.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui-3": patch
+---
+
+Fix issue where brand colours weren't customisable

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
     },
     "apps/docs": {
       "name": "forge-ui-3-styleguide",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "dependencies": {
         "@3squared/forge-playground-3": "*",
         "@3squared/forge-ui-3": "*",

--- a/packages/ui/src/styles/components/_tile.scss
+++ b/packages/ui/src/styles/components/_tile.scss
@@ -17,7 +17,12 @@
    @if $color == secondary {
      background-color: map-get($base-colors, "light") !important;
      border-color: black !important;
-   } @else {
+   } 
+   @else if $color == brand {
+     background-color: map-get($subtle-colors, $color + "-shade-1") !important;
+     border-color: map-get($base-colors, $color) !important;
+   }
+   @else{
      background-color: map-get($subtle-colors, $color + "-subtle") !important;
      border-color: map-get($base-colors, $color) !important;
    }

--- a/packages/ui/src/styles/utilities/_variables.scss
+++ b/packages/ui/src/styles/utilities/_variables.scss
@@ -3,9 +3,11 @@
 @import 'bootstrap/scss/variables-dark';
 
 //Forge Theme
-$brand: $indigo;
-$brand-light: $indigo-100;
-$brand-dark: $indigo-800;
+$brand: $indigo !default;
+$brand-dark: $indigo-800 !default;
+$brand-shade-1: $indigo-100 !default;
+$brand-shade-2: $indigo-300 !default;
+$brand-shade-3: $indigo-600 !default;
 
 $primary: #0077c8;
 $primary-dark: #006bb4;
@@ -41,7 +43,9 @@ $base-colors: (
 $badge-font-size: 0.75rem;
 
 $subtle-colors: (
-        'brand-subtle': $brand-light,
+        'brand-shade-1': $brand-shade-1,
+        'brand-shade-2': $brand-shade-2,
+        'brand-shade-3': $brand-shade-3,
         'primary-subtle': $primary-light,
         'success-subtle': $success-light,
         'warning-subtle': $warning-light,
@@ -66,7 +70,7 @@ $dark-colors: (
 $theme-colors: map-merge-multiple($theme-colors, $base-colors, $subtle-colors, $dark-colors);
 
 $brand-text-emphasis: shade-color($brand, 60%) !default;
-$brand-bg-subtle: $brand-light !default;
+$brand-bg-subtle: $brand-shade-1 !default;
 $brand-border-subtle: tint-color($brand-dark, 60%) !default;
 
 @import 'bootstrap/scss/maps';


### PR DESCRIPTION
Update brand variants so that:
- They are split out into brand shade 1, 2 and 3
- Specified as Default in SASS using the `!default` flag so that they can be customised in consuming projects.