### PR TITLE
Refactor multiselect

### DIFF
--- a/.changeset/yellow-terms-deliver.md
+++ b/.changeset/yellow-terms-deliver.md
@@ -1,0 +1,11 @@
+---
+"@3squared/forge-playground-3": patch
+"@3squared/forge-ui-3": patch
+"forge-ui-3-styleguide": patch
+---
+
+Refactor Forge Multiselect
+- Update checkbox to use ForgeCheckbox.
+- Update Chevron to use the Bootstrap Chevron.
+- Update Placeholder to update depending on if searchable is true or not.
+- Fix issue where including Searchable broke Forge Multiselect (https://github.com/3Squared/ForgeUI-3/issues/139).

--- a/apps/docs/src/pages/forms/dropdowns/Multiselect.vue
+++ b/apps/docs/src/pages/forms/dropdowns/Multiselect.vue
@@ -32,7 +32,7 @@ const multiSelectOptions = [
   { id: "option-5", label: "Option 5" },
   { id: "option-6", label: "Option 6" }
 ];
-const selected = ref([{ id: "option-1", label: "Option 1" }]);
+const selected = ref([]);
 
 const tagPositions = ["top", "bottom"];
 
@@ -46,11 +46,10 @@ const { options, propVals, config, reset } = usePlayground(
     selectValue: "",
     name: "",
     label: "label",
-    // TODO: Fix Searchable [Github Issue: https://github.com/3Squared/ForgeUI-3/issues/139]
-    //searchable: true,
+    searchable: true,
     clearOnSelect: true,
     hideSelected: false,
-    placeholder: "Select...",
+    placeholder: "Search",
     allowEmpty: true,
     resetAfter: false,
     closeOnSelect: false,

--- a/packages/playground/src/Playground.vue
+++ b/packages/playground/src/Playground.vue
@@ -8,7 +8,7 @@
           </div>
         </template>
       </Card>
-      <Card class="w-50 vh-70 overflow-auto">
+      <Card class="w-50 vh-70">
         <template #header>
           <div class="d-flex justify-content-between pb-2">
             <h1 class="h3">Options</h1>
@@ -22,7 +22,7 @@
           <slot name="header" />
         </template>
         <template #content>
-          <div class="scroll p-3 h-100">
+          <div class="p-3 h-100">
             <template v-for="(option, key) in props.options">
               <slot :name="key" v-bind="props.options">
                 <div v-if="isSelect(getConfig(key))">

--- a/packages/playground/src/main.scss
+++ b/packages/playground/src/main.scss
@@ -14,7 +14,8 @@ $codeBlockBackground: #282c34;
 }
 
 .card-body {
-  padding: 0
+  padding: 0;
+  overflow-y: scroll;
 }
 
 @import 'prismjs/themes/prism-tomorrow.css';

--- a/packages/ui/src/components/ForgeCheckbox.vue
+++ b/packages/ui/src/components/ForgeCheckbox.vue
@@ -17,7 +17,7 @@
 <script setup lang="ts" >
 import { CheckboxProps } from "primevue/checkbox";
 import { TypedSchema, useField } from "vee-validate";
-import { computed, watch } from "vue";
+import { computed, onMounted, watch } from "vue";
 type CheckProps = Omit<CheckboxProps, "aria-label" | "aria-labelledby">
 
 export interface ForgeCheckProps extends CheckProps {
@@ -47,9 +47,16 @@ const changeState = (event : Event) => {
   }
 }
 
+onMounted(() => {
+  if (props.value !== checked?.value) {
+    setValue(props.value)
+  }
+})
+
 const hasErrors = computed(() => errors.value.length > 0)
 
 watch(() => props.value, (value) => {
+
   if(value !== checked?.value)
   {
     setValue(value)

--- a/packages/ui/src/components/ForgeCheckbox.vue
+++ b/packages/ui/src/components/ForgeCheckbox.vue
@@ -36,8 +36,7 @@ const props = withDefaults(defineProps<ForgeCheckProps>(),
 
 const { checked, handleChange, setValue, errors, errorMessage } = useField(() => props.name ?? props.label, props.rules, {
   type: "checkbox",
-  checkedValue: true,
-  initialValue: props.modelValue
+  checkedValue: true
 })
 
 const changeState = (event : Event) => {
@@ -48,8 +47,10 @@ const changeState = (event : Event) => {
 }
 
 onMounted(() => {
-  if (props.value !== checked?.value) {
+  if (props.value !== undefined && props.value !== checked?.value) {
     setValue(props.value)
+  } else if (props.modelValue !== undefined && props.modelValue !== checked?.value){
+    setValue(props.modelValue)
   }
 })
 

--- a/packages/ui/src/components/ForgeCheckbox.vue
+++ b/packages/ui/src/components/ForgeCheckbox.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="d-flex" data-cy="checkbox-container">
-    <Checkbox :id="props.name" v-bind="{...$attrs, ...props}" :value="checked" :input-class="{'is-invalid': hasErrors }" @change="changeState">
+    <Checkbox :id="props.name" v-bind="{...$attrs, ...props}" v-model="checked" :input-class="{'is-invalid': hasErrors }" @change="changeState">
       <template #icon>
         <div />
       </template>
     </Checkbox>
-    <label :for="props.name" :class="'form-check-label' && `${props.disabled ? 'opacity-50' : 'cursor-pointer'}`" @click="changeState">
+    <label :for="props.name" :class="`${props.disabled ? 'opacity-50' : 'cursor-pointer'}`" @click="changeState">
       <slot>{{ props.label }}</slot>
     </label>
   </div>
@@ -17,7 +17,7 @@
 <script setup lang="ts" >
 import { CheckboxProps } from "primevue/checkbox";
 import { TypedSchema, useField } from "vee-validate";
-import { computed } from "vue";
+import { computed, watch } from "vue";
 type CheckProps = Omit<CheckboxProps, "aria-label" | "aria-labelledby">
 
 export interface ForgeCheckProps extends CheckProps {
@@ -34,7 +34,7 @@ const props = withDefaults(defineProps<ForgeCheckProps>(),
     })
 
 
-const { checked, handleChange, errors, errorMessage } = useField(() => props.name ?? props.label, props.rules, {
+const { checked, handleChange, setValue, errors, errorMessage } = useField(() => props.name ?? props.label, props.rules, {
   type: "checkbox",
   checkedValue: true,
   initialValue: props.modelValue
@@ -48,4 +48,11 @@ const changeState = (event : Event) => {
 }
 
 const hasErrors = computed(() => errors.value.length > 0)
+
+watch(() => props.value, (value) => {
+  if(value !== checked?.value)
+  {
+    setValue(value)
+  }
+})
 </script>

--- a/packages/ui/src/components/ForgeMultiSelect.vue
+++ b/packages/ui/src/components/ForgeMultiSelect.vue
@@ -20,6 +20,13 @@
         </ForgeCheckbox>
       </div>
     </template>
+    <template #tag="{option, remove}">
+      <div class="multiselect__tag d-inline-flex">
+        <div class="my-auto">{{ option.label }}</div>
+        <Icon icon="bi:x" class="my-auto multiselect__tag-icon" @mousedown.prevent.stop="removeElement(remove, option)"
+              height="18px" width="18px"  />
+      </div>
+    </template>
     <slot v-for="(_, name) in $slots" :slot="name" :name="name" />
   </VueMultiselect>
   <small v-show="hasErrors" data-cy="error" class="invalid-feedback">{{ errorMessage }}</small>
@@ -64,6 +71,15 @@ const props = withDefaults(defineProps<ForgeMultiSelectProps>(), {
   selectValue: "",
   name: ""
 })
+
+const removeElement = (remove : Function, element : any) => {
+  const elementToRemove = {
+    ...element,
+    $isDisabled: element.$isDisabled ?? false
+  }
+  
+  remove(elementToRemove);
+}
 
 const attrs = useAttrs()
 const emits = defineEmits(['update:modelValue'])

--- a/packages/ui/src/components/ForgeMultiSelect.vue
+++ b/packages/ui/src/components/ForgeMultiSelect.vue
@@ -1,27 +1,23 @@
 <template>
   <VueMultiselect v-bind="multiselectProps" :class="[theme, hasErrors ? 'is-invalid' : '']" data-cy="multiselect" @update:modelValue="select" v-model="value" >
-    <template #caret="{ toggle }" v-if="shouldShowClearSelection">
-      <Icon icon="bi:x" class="my-auto multiselect__clear-icon" @mousedown.prevent.stop="clearSelected()" data-cy="clear"/>
-      <div class="multiselect__select" @mousedown.prevent.stop="toggle"></div>
+    <template #caret="{ toggle }">
+      <Icon icon="bi:x" class="my-auto multiselect__clear-icon" @mousedown.prevent.stop="clearSelected()" data-cy="clear" height="18px" width="18px" v-if="shouldShowClearSelection"/>
+      <Icon icon="bi:chevron-down" @click="toggle" class="multiselect__select" />
     </template>
     <template v-if="multiselectProps.multiple && showSelectAll && !multiselectProps.async" #beforeList>
       <li class="multiselect__element" @click="selectAll" @mouseover="onMouseOver" @mouseleave="onMouseLeave" data-cy="toggle-all">
-        <span :class="`multiselect__option ${optionHighlight}`">
-          <input :checked="isAllSelected" name="selected" type="checkbox"
-                 class="multiselect__option--checkbox" />
-          <strong>Select all</strong>
+        <span :class="`${optionHighlight}`">
+          <ForgeCheckbox :value="isAllSelected">
+            <div class="ps-1">Select all</div>
+          </ForgeCheckbox>
         </span>
       </li>
     </template>
     <template v-if="multiselectProps.multiple" #option="{option}" >
       <div :data-cy="option.label">
-        <input
-            :checked="isChecked(option)"
-            name="selected"
-            type="checkbox"
-            class="multiselect__option--checkbox"
-        />
-        {{ option[multiselectProps.label] }}
+        <ForgeCheckbox :value="isChecked(option)" :key="option">
+          <div class="ps-1">{{ option[multiselectProps.label] }}</div>
+        </ForgeCheckbox>
       </div>
     </template>
     <slot v-for="(_, name) in $slots" :slot="name" :name="name" />
@@ -82,12 +78,12 @@ const multiselectProps = computed<VueMultiSelectDefaults>(() => {
     label: "label",
     trackBy: "id",
     showPointer: !selectAllHighlighted.value,
-    placeholder: "Select...",
+    placeholder: !!((attrs.searchable === null || attrs.searchable)) ? "Search" : "Select",
     allowEmpty: true,
     selectValue: '',
     closeOnSelect: !!(attrs.multiple === null || attrs.multiple),
     clearOnSelect: !!(attrs.multiple === null || attrs.multiple),
-    searchable: !!((attrs.searchable === null || attrs.searchable) && !isAllSelected.value),
+    searchable: !!((attrs.searchable === null || attrs.searchable)) && (attrs.modelValue as Array<any>).length === (attrs.options as Array<any>).length,
     async: false,
     ...attrs
   }
@@ -95,7 +91,7 @@ const multiselectProps = computed<VueMultiSelectDefaults>(() => {
 
 const theme = computed<string>(() => `forge-multiselect-${props.severity}`)
 
-const optionHighlight = computed<string>(() => `multiselect-option ${selectAllHighlighted.value ? ' multiselect__option--highlight' : ''} ${isAllSelected.value ? ' multiselect__option--selected' : ''}`)
+const optionHighlight = computed<string>(() => `multiselect__option ${selectAllHighlighted.value ? ' multiselect__option--highlight' : ''} ${isAllSelected.value ? ' multiselect__option--selected' : ''}`)
 
 const isAllSelected = computed<boolean>(() => {
   if (multiselectProps.value && !(multiselectProps.value.multiple || !props.showSelectAll || multiselectProps.value.async)) {

--- a/packages/ui/src/styles/components/_multiselect.scss
+++ b/packages/ui/src/styles/components/_multiselect.scss
@@ -156,43 +156,18 @@
     }
 
     .multiselect__tag-icon {
-      cursor: pointer;
-      margin-left: 7px;
-      position: absolute;
-      right: 0;
-      top: 0;
-      bottom: 0;
-      font-weight: 400;
-      font-style: initial;
-      width: 22px;
-      text-align: center;
-      line-height: 21px;
-      transition: all 0.2s ease;
-      border-radius: 0;
-      border-left: 1px solid #ffffff
-    }
-
-    .multiselect__tag-icon:after {
-      content: "×";
-      color: #ffffff;
-      font-size: 14px;
+      position: unset;
+      margin-left: 8px;
+      margin-right: 4px;
     }
     
     .multiselect__tag {
-      background: $value;
-      position: relative;
-      display: inline-block;
-      padding: 4px 26px 4px 8px;
-      border-radius: 0;
-      color: #fff;
-      line-height: 1;
+      background: map-get($subtle-colors, $color + "-subtle");
+      padding: 4px 3px 4px 10px;
+      border-radius: 21px;
+      border: 1px solid $value;
+      color: $value;
       margin: 2.5px;
-      white-space: normal;
-      overflow: hidden;
-      max-width: 100%;
-      text-overflow: ellipsis;
-      font-weight: 400;
-      z-index: 2;
     }
 
     .multiselect__option {

--- a/packages/ui/src/styles/components/_multiselect.scss
+++ b/packages/ui/src/styles/components/_multiselect.scss
@@ -105,10 +105,10 @@
       display: block;
       position: absolute;
       box-sizing: border-box;
-      width: 25px;
-      height: 25px;
-      right: 1px;
-      top: 4px;
+      width: 16px;
+      height: 16px;
+      right: 8px;
+      top: 28%;
       padding: unset;
       margin: 0;
       margin-top: auto;
@@ -119,18 +119,19 @@
       transition: transform 0.2s ease;
     }
 
-    .multiselect__select:before {
-      position: relative;
-      right: 0;
-      top: 65%;
-      color: $gray-700;
-      margin-top: 3px;
-      border-style: solid;
-      border-width: 5px 5px 0 5px;
-      border-color: #999999 transparent transparent transparent;
-      content: "";
+    .multiselect__clear-icon {
+      position: absolute;
+      right: 26px;
+      top: 25%;
+      cursor: pointer;
+      transition: transform 0.2s ease;
     }
 
+    .multiselect__clear-icon:focus,
+    .multiselect__clear-icon:hover {
+      color: #ff0000;
+    }
+    
     .multiselect__tags {
       min-height: 31px;
       display: block;
@@ -154,6 +155,29 @@
       -webkit-overflow-scrolling: touch;
     }
 
+    .multiselect__tag-icon {
+      cursor: pointer;
+      margin-left: 7px;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      font-weight: 400;
+      font-style: initial;
+      width: 22px;
+      text-align: center;
+      line-height: 21px;
+      transition: all 0.2s ease;
+      border-radius: 0;
+      border-left: 1px solid #ffffff
+    }
+
+    .multiselect__tag-icon:after {
+      content: "×";
+      color: #ffffff;
+      font-size: 14px;
+    }
+    
     .multiselect__tag {
       background: $value;
       position: relative;
@@ -232,29 +256,6 @@
       accent-color: $value;
     }
 
-    .multiselect__tag-icon {
-      cursor: pointer;
-      margin-left: 7px;
-      position: absolute;
-      right: 0;
-      top: 0;
-      bottom: 0;
-      font-weight: 400;
-      font-style: initial;
-      width: 22px;
-      text-align: center;
-      line-height: 21px;
-      transition: all 0.2s ease;
-      border-radius: 0;
-      border-left: 1px solid #ffffff
-    }
-
-    .multiselect__tag-icon:after {
-      content: "×";
-      color: #ffffff;
-      font-size: 14px;
-    }
-
     .multiselect__tag-icon:focus,
     .multiselect__tag-icon:hover {
       background: none;
@@ -262,38 +263,6 @@
 
     .multiselect__tag-icon:focus:after,
     .multiselect__tag-icon:hover:after {
-      color: #ff0000;
-    }
-
-    .multiselect__clear-icon {
-      cursor: pointer;
-      position: absolute;
-      right: 20px;
-      top: 1px;
-      bottom: 0;
-      font-weight: 400;
-      font-style: initial;
-      width: 22px;
-      text-align: center;
-      line-height: 21px;
-      transition: all 0.2s ease;
-      border-radius: 0;
-      z-index: 1;
-    }
-
-    .multiselect__clear-icon:after {
-      content: "×";
-      color: $gray-800;
-      font-size: 14px;
-    }
-
-    .multiselect__clear-icon:focus,
-    .multiselect__clear-icon:hover {
-      background: none;
-    }
-
-    .multiselect__clear-icon:focus:after,
-    .multiselect__clear-icon:hover:after {
       color: #ff0000;
     }
   }

--- a/packages/ui/src/styles/components/_multiselect.scss
+++ b/packages/ui/src/styles/components/_multiselect.scss
@@ -162,7 +162,11 @@
     }
     
     .multiselect__tag {
-      background: map-get($subtle-colors, $color + "-subtle");
+      @if($color == "brand") {
+        background: map-get($subtle-colors, "brand-shade-1");
+      } @else {
+        background: map-get($subtle-colors, $color + "-subtle");
+      }
       padding: 4px 3px 4px 10px;
       border-radius: 21px;
       border: 1px solid $value;

--- a/packages/ui/tests/component/checkbox/checkbox.cy.ts
+++ b/packages/ui/tests/component/checkbox/checkbox.cy.ts
@@ -32,7 +32,7 @@ describe("<ForgeCheckbox />", () => {
     // Act
     cy.mount(ForgeCheckbox, {
       props: {
-        modelValue: true,
+        value: true,
         binary: true,
         name: id,
         label: label

--- a/packages/ui/tests/component/checkbox/checkbox.cy.ts
+++ b/packages/ui/tests/component/checkbox/checkbox.cy.ts
@@ -32,7 +32,7 @@ describe("<ForgeCheckbox />", () => {
     // Act
     cy.mount(ForgeCheckbox, {
       props: {
-        value: true,
+        modelValue: true,
         binary: true,
         name: id,
         label: label

--- a/packages/ui/tests/component/multiselect/multiselect.cy.ts
+++ b/packages/ui/tests/component/multiselect/multiselect.cy.ts
@@ -79,7 +79,7 @@ describe("<ForgeMultiselect />", () => {
     
     it("Allows the user to unselect an option by clicking on a selected option", () => {
       // Arrange
-      const expectedPlaceholder = "Select..."
+      const expectedPlaceholder = "Select"
       
       // Act
       mountMultiselect({ options: options })
@@ -121,6 +121,32 @@ describe("<ForgeMultiselect />", () => {
     })
   })
   
+  describe("Placeholder", () => {
+    it("Should default to Search if searchable is true", () => {
+      // Arrange
+      const expectedPlaceholder = "Search"
+
+      // Act
+      mountMultiselect({ options: options, searchable: true })
+
+      // Assert
+      cy.get(inputId)
+        .should('contain.text', expectedPlaceholder)
+    })
+
+    it("Should default to Select if searchable is false", () => {
+      // Arrange
+      const expectedPlaceholder = "Select"
+
+      // Act
+      mountMultiselect({ options: options, searchable: false })
+
+      // Assert
+      cy.get(inputId)
+        .should('contain.text', expectedPlaceholder)
+    })
+  })
+  
   describe("Clear button", () => {
     it("Displays a clear button in the multiselect when showClearSelection is true", () => {
       // Arrange
@@ -140,7 +166,7 @@ describe("<ForgeMultiselect />", () => {
 
     it('Clears all selected options on click of the clear button', () => {
       // Arrange
-      const expectedPlaceholder = "Select..."
+      const expectedPlaceholder = "Select"
       const showClearSelection = true
 
       // Act
@@ -202,7 +228,7 @@ describe("<ForgeMultiselect />", () => {
     it("Unselects all options on toggle off of select all", () => {
       // Arrange
       const showSelectAll = true
-      const expectedPlaceholder = "Select..."
+      const expectedPlaceholder = "Select"
 
       // Act
       mountMultiselect({ options: options, showSelectAll: showSelectAll })


### PR DESCRIPTION
Refactor Forge Multiselect
- Update checkbox to use ForgeCheckbox.
- Update Chevron to use the Bootstrap Chevron.
- Update Placeholder to update depending on if searchable is true or not.
- Fix issue where including Searchable broke Forge Multiselect (https://github.com/3Squared/ForgeUI-3/issues/139).