### PR TITLE
Forge link text doesn't break when it is inside a container

### DIFF
--- a/.changeset/small-dogs-taste.md
+++ b/.changeset/small-dogs-taste.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui-3": patch
+---
+
+Fix issue where ForgeLink wouldn't wrap text when inside a container.

--- a/packages/ui/src/components/ForgeLink.vue
+++ b/packages/ui/src/components/ForgeLink.vue
@@ -1,7 +1,7 @@
 <template>
   <a
       id="link"
-      class="cursor-pointer d-flex"
+      class="cursor-pointer d-flex text-break"
       :href="url"
       :target="target"
       :class="linkClasses"


### PR DESCRIPTION
Fix issue where ForgeLink wouldn't wrap text when inside a container.