### PR TITLE
Fix label toggle

### DIFF
--- a/.changeset/little-poems-invent.md
+++ b/.changeset/little-poems-invent.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui-3": patch
+---
+
+Fix checkbox to make label trigger change event when validation is not used

--- a/packages/ui/src/components/ForgeCheckbox.vue
+++ b/packages/ui/src/components/ForgeCheckbox.vue
@@ -58,7 +58,6 @@ const { handleChange, errors, errorMessage } = useField(
 );
 
 const onChange = (checkValue: boolean) => {
-  console.log(checkValue);
   if(props.name) handleChange(checkValue)
   else value.value = checkValue
 }

--- a/packages/ui/src/components/ForgeCheckbox.vue
+++ b/packages/ui/src/components/ForgeCheckbox.vue
@@ -1,19 +1,33 @@
 <template>
   <div class="d-flex flex-column">
-    <div class="d-flex cursor-pointer" data-cy="checkbox-container" @click="handleChange(value)" v-bind="{...$attrs}">
-      <Checkbox v-bind="{ ...props }" binary v-model="value"
-                :input-id="props.name" :input-class="{'is-invalid': hasErrors }"
+    <div
+      class="d-flex cursor-pointer"
+      data-cy="checkbox-container"
+      @click="onChange(value)"
+      v-bind="{ ...$attrs }"
+    >
+      <Checkbox
+        v-bind="{ ...props }"
+        binary
+        v-model="value"
+        :input-id="props.name"
+        :input-class="{ 'is-invalid': hasErrors }"
       />
-      <label :for="props.name" @click="handleChange(value)"
-             :class="`${props.disabled ? 'opacity-50' : 'cursor-pointer'} ${hasErrors ? 'text-danger-dark' : ''}`"
-             class="w-100 my-auto"
+      <label
+        :for="props.name"
+        @click="onChange(!value)"
+        :class="`${props.disabled ? 'opacity-50' : 'cursor-pointer'} ${
+          hasErrors ? 'text-danger-dark' : ''
+        }`"
+        class="w-100 my-auto"
       >
         <slot>{{ props.label }}</slot>
       </label>
     </div>
-    <small data-cy="error" class="text-invalid" v-show="hasErrors">{{ errorMessage }}</small>
+    <small data-cy="error" class="text-invalid" v-show="hasErrors">{{
+      errorMessage
+    }}</small>
   </div>
-
 </template>
 
 <script setup lang="ts">
@@ -21,29 +35,33 @@ import { useField } from "vee-validate";
 import { computed } from "vue";
 import { CheckboxProps } from "primevue/checkbox";
 
-type CheckProps = Omit<CheckboxProps, "aria-label" | "aria-labelledby">
+type CheckProps = Omit<CheckboxProps, "aria-label" | "aria-labelledby">;
 
 export interface ForgeCheckProps extends CheckProps {
-  label: string
+  label: string;
 }
 
-const props = withDefaults(defineProps<ForgeCheckProps>(),
-    {
-      binary: true,
-      label: ""
-    })
+const props = withDefaults(defineProps<ForgeCheckProps>(), {
+  binary: true,
+  label: "",
+});
 
-const value = defineModel<boolean>({ required: true })
+const value = defineModel<boolean>({ required: true });
 
-const {
-  handleChange,
-  errors,
-  errorMessage
-} = useField(() => props.name ?? "", undefined, {
-  type: "checkbox",
-  checkedValue: value.value
-})
+const { handleChange, errors, errorMessage } = useField(
+  () => props.name ?? "",
+  undefined,
+  {
+    type: "checkbox",
+    checkedValue: value.value,
+  }
+);
 
-const hasErrors = computed(() => errors.value.length > 0)
+const onChange = (checkValue: boolean) => {
+  console.log(checkValue);
+  if(props.name) handleChange(checkValue)
+  else value.value = checkValue
+}
 
+const hasErrors = computed(() => errors.value.length > 0);
 </script>


### PR DESCRIPTION
Bug Raised (dev-ops description):
The ForgeCheckbox component can only be toggled using the click of the label if the name prop is provided. I think this is to do with the `handleChange` event which is called as this comes directly from Vee-Validate. You'll probably have to update this so that it calls the `handleChange` method if the name prop is provided else it should just update the model.

