### PR TITLE
Fix file type check and update docs

### DIFF
--- a/.changeset/rotten-lamps-cheat.md
+++ b/.changeset/rotten-lamps-cheat.md
@@ -1,0 +1,6 @@
+---
+"@3squared/forge-ui-3": patch
+"forge-ui-3-styleguide": patch
+---
+
+Fix file type validation to use ForgeFileType object instead of a string

--- a/apps/docs/src/pages/forms/FileUploader.vue
+++ b/apps/docs/src/pages/forms/FileUploader.vue
@@ -31,12 +31,12 @@ const { options, propVals, config, reset } = usePlayground({
   autoUploadToBlob: true
 });
 
-const acceptedTypes = [{ fileType: "image/jpeg" }, { fileType: "image/gif", label: "GIF" }, { fileType: "image/csv", label: "CSV" }] as ForgeFileType[];
+const acceptedTypes = [{ fileType: "image/jpeg" }, { fileType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", label: "docx" }, { fileType: "image/gif", label: "GIF" }, { fileType: "image/csv", label: "CSV" }] as ForgeFileType[];
 
 const code = computed(
   () =>
     `    <template>
-      <ForgeFileUploader :accepted-file-types="['image/jpeg', 'application/pdf', 'text/csv']" get-file-url-action="yourFunction"${propVals.value.length > 0 ? " " + propVals.value.join(" ") : ""} />
+      <ForgeFileUploader :accepted-file-types="acceptedTypes" get-file-url-action="yourFunctionThatGetsContainerUrlForFile"${propVals.value.length > 0 ? " " + propVals.value.join(" ") : ""} />
     </template>
     
     <script setup lang="ts">
@@ -45,6 +45,7 @@ const code = computed(
       // Add custom labels to file types using the 'label' prop.
       const acceptedTypes = [
         { fileType: 'image/jpeg' },
+        { fileType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", label: "docx" }
         { fileType: 'image/gif', label: 'GIF' },
         { fileType: 'image/csv', label: 'CSV' }
       ] as ForgeFileType[]

--- a/apps/docs/src/pages/forms/FileUploader.vue
+++ b/apps/docs/src/pages/forms/FileUploader.vue
@@ -31,7 +31,12 @@ const { options, propVals, config, reset } = usePlayground({
   autoUploadToBlob: true
 });
 
-const acceptedTypes = [{ fileType: "image/jpeg" }, { fileType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", label: "docx" }, { fileType: "image/gif", label: "GIF" }, { fileType: "image/csv", label: "CSV" }] as ForgeFileType[];
+const acceptedTypes = [
+  { fileType: "image/jpeg" },
+  { fileType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", label: "docx" },
+  { fileType: "image/gif", label: "GIF" },
+  { fileType: "image/csv", label: "CSV" }
+] as ForgeFileType[];
 
 const code = computed(
   () =>

--- a/packages/ui/src/components/file-uploader/components/FileInfo.vue
+++ b/packages/ui/src/components/file-uploader/components/FileInfo.vue
@@ -49,10 +49,11 @@ import {TypedSchema} from "vee-validate";
 import {computed, ref, onMounted} from "vue";
 import UploadStatus from "@/components/file-uploader/components/UploadStatus.vue";
 import {BlockBlobClient, BlockBlobParallelUploadOptions} from "@azure/storage-blob";
+import { ForgeFileType } from "../../../types/forge-types";
 
 interface FileInfoProps {
-  editableFileName: boolean,
-  acceptedFileTypes: string,
+  editableFileName: File,
+  acceptedFileTypes: ForgeFileType[],
   maxFileSize: number,
   getFileUrlAction: (fileName : string) => Promise<[string, string]>,
   customFileNameRules?: TypedSchema,
@@ -71,14 +72,14 @@ const blobUploadUrl = ref<string>("")
 const bytesUploaded = ref<number>(0)
 const controller = ref();
 
-const validFileType = computed<boolean>(() => acceptedFileTypes.includes(file.value.type))
+const validFileType = computed<boolean>(() => acceptedFileTypes.some(({fileType}) => fileType === file.value.type))
 const validFileSize = computed<boolean>(() => file.value.size <= maxFileSize)
 
 const updateFileName = () => {
   file.value = new File([file.value], fileName.value, { type: file.value.type, lastModified: (new Date()).valueOf()})
 }
 
-const uploadBlob = async () => {
+const uploadBlob = async () => {  
   if(!validFileType.value || !validFileSize.value){
     uploadStatus.value = !validFileType.value ? 'InvalidFileType' : 'InvalidFileSize'
     return;

--- a/packages/ui/src/components/file-uploader/components/FileInfo.vue
+++ b/packages/ui/src/components/file-uploader/components/FileInfo.vue
@@ -52,7 +52,7 @@ import {BlockBlobClient, BlockBlobParallelUploadOptions} from "@azure/storage-bl
 import { ForgeFileType } from "../../../types/forge-types";
 
 interface FileInfoProps {
-  editableFileName: File,
+  editableFileName: boolean,
   acceptedFileTypes: ForgeFileType[],
   maxFileSize: number,
   getFileUrlAction: (fileName : string) => Promise<[string, string]>,


### PR DESCRIPTION
Fix file type validation to use ForgeFileType object instead of a string