### PR TITLE
Add file type and content dispotion headers to Blob upload

### DIFF
--- a/.changeset/fuzzy-suns-worry.md
+++ b/.changeset/fuzzy-suns-worry.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui-3": patch
+---
+
+Installed Mime package, added forge mime type to utilities and to file info. This allows us to send the content type and disposition header to blob

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
     },
     "apps/docs": {
       "name": "forge-ui-3-styleguide",
-      "version": "1.17.1",
+      "version": "1.17.2",
       "dependencies": {
         "@3squared/forge-playground-3": "*",
         "@3squared/forge-ui-3": "*",
@@ -9248,6 +9248,20 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.4.tgz",
+      "integrity": "sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -13537,7 +13551,7 @@
     },
     "packages/ui": {
       "name": "@3squared/forge-ui-3",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
@@ -13546,6 +13560,7 @@
         "@popperjs/core": "^2.11.8",
         "@vueuse/components": "^10.6.1",
         "bootstrap": "^5.3.3",
+        "mime": "^4.0.4",
         "primevue": "^3.53.1",
         "vee-validate": "^4.11.8",
         "vue": "^3.4.14",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,6 +35,7 @@
     "@popperjs/core": "^2.11.8",
     "@vueuse/components": "^10.6.1",
     "bootstrap": "^5.3.3",
+    "mime": "^4.0.4",
     "primevue": "^3.53.1",
     "vee-validate": "^4.11.8",
     "vue": "^3.4.14",
@@ -48,15 +49,15 @@
     "@vitest/ui": "2.1.6",
     "cypress": "13.16.0",
     "cypress-real-events": "1.13.0",
+    "rollup-plugin-visualizer": "5.12.0",
     "sass": "1.81.0",
     "typescript": "5.7.2",
     "unplugin-vue-components": "0.27.5",
-    "rollup-plugin-visualizer": "5.12.0",
     "vite": "5.4.11",
     "vite-bundle-visualizer": "1.2.1",
+    "vite-plugin-dts": "3.9.1",
     "vite-plugin-istanbul": "6.0.2",
-    "vitest": "2.1.6",
-    "vite-plugin-dts": "3.9.1"
+    "vitest": "2.1.6"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.27.4"

--- a/packages/ui/src/components/file-uploader/utilities/utilities.ts
+++ b/packages/ui/src/components/file-uploader/utilities/utilities.ts
@@ -1,5 +1,8 @@
 import { ForgeFileStatus } from "../../../types/forge-types";
 import { BlockBlobClient } from "@azure/storage-blob";
+﻿import { Mime } from "mime";
+import standardTypes from "mime/types/standard.js";
+import otherTypes from "mime/types/other.js";
 
 export type FileUploadStatus =
   "Not Uploaded"
@@ -83,5 +86,11 @@ export function isImage(mimeType: string): boolean {
 
 export function getThumbnailUrl(file: File) {
   return URL.createObjectURL(file)
+}
+
+export function forgeMime(): Mime {
+  const mime = new Mime(standardTypes, otherTypes);
+  mime.define({ "application/vnd.ms-outlook": ["pst"] });
+  return mime;
 }
 


### PR DESCRIPTION
Installed Mime package, added forge mime type to utilities and to file info. This allows us to send the content type and disposition header to blob