### PR TITLE
Fix issue with scratchpad line being jagged.

### DIFF
--- a/.changeset/stale-items-fly.md
+++ b/.changeset/stale-items-fly.md
@@ -1,0 +1,6 @@
+---
+"@3squared/forge-ui-3": patch
+"forge-ui-3-styleguide": patch
+---
+
+Fix scratchpad line interpolation, by adding default lineJoin of round

--- a/packages/ui/src/components/ForgeScratchpad.vue
+++ b/packages/ui/src/components/ForgeScratchpad.vue
@@ -9,6 +9,7 @@
         :height="height"
         :width="width"
         :style="`height: ${height}px; width: ${width}px`"
+        line-join="round"
     />
     <div class="d-flex flex-row mt-1 gap-1">
       <Button v-if="props.showUndo" @click="undo" outlined data-cy="undo-button">Undo</Button>
@@ -30,6 +31,7 @@ export interface ScratchpadProps {
   showSave?: boolean,
   height?: number,
   width?: number,
+  lineJoin?: string
 }
 
 const props = withDefaults(defineProps<ScratchpadProps>(), {
@@ -38,7 +40,8 @@ const props = withDefaults(defineProps<ScratchpadProps>(), {
   showRedo: true,
   showSave: true,
   height: 300,
-  width: 600
+  width: 600,
+  lineJoin: 'round'
 })
 
 const emit = defineEmits(['save'])

--- a/packages/ui/src/components/ForgeScratchpad.vue
+++ b/packages/ui/src/components/ForgeScratchpad.vue
@@ -9,7 +9,7 @@
         :height="height"
         :width="width"
         :style="`height: ${height}px; width: ${width}px`"
-        line-join="round"
+        :line-join="lineJoin"
     />
     <div class="d-flex flex-row mt-1 gap-1">
       <Button v-if="props.showUndo" @click="undo" outlined data-cy="undo-button">Undo</Button>


### PR DESCRIPTION
Add in a defualt of line-join 'round' to smooth out the lines, as per this issue: https://github.com/razztyfication/vue-drawing-canvas/issues/28