### PR TITLE
enhance passthrough to automatically change dropdown alignment when overflowing

### DIFF
--- a/.changeset/sour-turtles-follow.md
+++ b/.changeset/sour-turtles-follow.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui-3": patch
+---
+
+Fix passthrough for splitbutton dropdown to allow for automatic alignment instead of pageoverflow

--- a/apps/docs/src/pages/buttons/SplitButton.vue
+++ b/apps/docs/src/pages/buttons/SplitButton.vue
@@ -6,6 +6,9 @@
       <a class="link" target="_blank" href="https://primevue.org/button/"><strong>PrimeVue documentation</strong></a>
       .
     </p>
+    <p>
+      <b>IMPORTANT:</b> Please make sure to pass in an <code>id</code> attribute when using SplitButtons to make sure the dropdown alignment is correct.
+    </p>
     <Playground :options="options" :code="code" :config="config" @reset="reset">
       <template #component>
         <component :is="SplitButton" v-bind="options" :model="items" @click="save" />
@@ -53,12 +56,14 @@ const save = () => {
 
 const { options, propVals, config, reset } = usePlayground(
   {
+    id: "my-unique-id",
     label: "Button",
     severity: severities[0],
     outlined: false,
     size: ""
   },
   {
+    id: { required: true },
     label: { required: true },
     size: { type: "select", options: sizes },
     severity: { type: "select", options: severities }

--- a/packages/ui/src/passthroughs/SplitButton.pt.ts
+++ b/packages/ui/src/passthroughs/SplitButton.pt.ts
@@ -34,6 +34,11 @@ export default {
     pcMenu: {
       rootList: ({instance}: TieredMenuPassThroughMethodOptions<any>) => {
         const classes = ['dropdown-menu show']
+        // We do some calculations here to figure out if the dropdown expands beyond the page width
+        // this can happen often if the splitbutton is positioned towards the right of the page and then gets fed in long worded options
+        // without this tweak, the page will expand outwards, which looks wrong
+        // this fix adds another css class which aligns the dropdown to the right side, causing long options to expand into the page, instead of outwards
+        // in every other scenario, the dropdown expands as it did before
         const ul = document.querySelector(`ul[teleported-from=${instance.$el.parentElement.id}]`)
         if(ul?.parentElement?.offsetLeft + ul?.offsetWidth > window.innerWidth)
           classes.push('dropdown-menu-end')

--- a/packages/ui/src/passthroughs/SplitButton.pt.ts
+++ b/packages/ui/src/passthroughs/SplitButton.pt.ts
@@ -1,4 +1,5 @@
 import { SplitButtonPassThroughMethodOptions } from "primevue/splitbutton";
+import { TieredMenuPassThroughMethodOptions } from "primevue";
 
 export default {
   splitbutton: {
@@ -31,9 +32,19 @@ export default {
       })
     },
     pcMenu: {
-      rootList: 'dropdown-menu show w-100',
-      item: 'dropdown-item',
-      separator: 'border-bottom w-100'
+      rootList: ({instance}: TieredMenuPassThroughMethodOptions<any>) => {
+        const classes = ['dropdown-menu show']
+        const ul = document.querySelector(`ul[teleported-from=${instance.$el.parentElement.id}]`)
+        if(ul?.parentElement?.offsetLeft + ul?.offsetWidth > window.innerWidth)
+          classes.push('dropdown-menu-end')
+        return {
+          'teleported-from': instance.$el.parentElement.id,
+          'data-bs-popper': '',
+          class: classes
+        }
+      },
+      itemLink: 'dropdown-item',
+      separator: 'border-bottom'
     }
   }
 }


### PR DESCRIPTION
This fixes an issue with the splitbutton dropdown reaching out of the page (e.g. when the dropdown is towards the right side of the page and it gets fed long options), by making the dropdown right aligned if that is happening, this ensures that long options will expand into the page towards the left instead.

In any other cases, the dropdown behaves the same as before