### PR TITLE
Add file uploader fixes

### DIFF
--- a/.changeset/hip-wings-know.md
+++ b/.changeset/hip-wings-know.md
@@ -1,0 +1,11 @@
+---
+"@3squared/forge-ui-3": minor
+"forge-ui-3-styleguide": minor
+---
+
+Changes:
+- Add `inLine` version of  `ForgeLoader`: a smaller version so it can for showing the uploading status of each file in the file uploader.
+- `ForgeFileUploader`:
+  - Fix functionality to stop file upload
+  - Stop files from uploading again if new files are added
+- Make severity optional for `ForgeTile`

--- a/apps/docs/components.d.ts
+++ b/apps/docs/components.d.ts
@@ -8,6 +8,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    ForgePageHeader: typeof import('@3squared/forge-ui-3')['ForgePageHeader']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
   }

--- a/apps/docs/src/pages/examples/components/ExampleFileUploader.vue
+++ b/apps/docs/src/pages/examples/components/ExampleFileUploader.vue
@@ -10,13 +10,15 @@
 
 <script setup lang="ts">
 import { ForgeFileUploader } from "@3squared/forge-ui-3";
-import { ForgeFileType, ForgeFileStatus } from "@3squared/forge-ui-3/src/types/forge-types.ts";
+import { ForgeFileStatus, ForgeFileType } from "@3squared/forge-ui-3/src/types/forge-types.ts";
 import { ref } from "vue";
 
 const file = ref<ForgeFileStatus[]>();
 // Add custom labels to file types using the 'label' prop.
 const acceptedTypes = [
   { fileType: "image/jpeg" },
+  { fileType: "image/jpg" },
+  { fileType: "image/png" },
   { fileType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", label: "docx" },
   { fileType: "image/gif", label: "GIF" },
   { fileType: "image/csv", label: "CSV" },

--- a/apps/docs/src/pages/layout/Loader.vue
+++ b/apps/docs/src/pages/layout/Loader.vue
@@ -22,7 +22,8 @@ import { severities } from "../../composables/playgroundOptions";
 
 const { options, propVals, config, reset } = usePlayground(
   {
-    severity: severities[0]
+    severity: severities[0],
+    inLine: false
   },
   {
     severity: { type: "select", options: severities }

--- a/packages/ui/components.d.ts
+++ b/packages/ui/components.d.ts
@@ -51,18 +51,13 @@ declare module 'vue' {
     Message: typeof import('primevue/message')['default']
     MultiSelect: typeof import('primevue/multiselect')['default']
     Panel: typeof import('primevue/panel')['default']
-    Popover: typeof import('primevue/popover')['default']
     ProgressBar: typeof import('primevue/progressbar')['default']
     ProgressSpinner: typeof import('primevue/progressspinner')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     Select: typeof import('primevue/select')['default']
-    TabPanels: typeof import('primevue/tabpanels')['default']
     Textarea: typeof import('primevue/textarea')['default']
     UploadButton: typeof import('./src/components/file-uploader/components/UploadButton.vue')['default']
     UploadStatus: typeof import('./src/components/file-uploader/components/UploadStatus.vue')['default']
-  }
-  export interface ComponentCustomProperties {
-    Tooltip: typeof import('primevue/tooltip')['default']
   }
 }

--- a/packages/ui/src/components/ForgeLoader.vue
+++ b/packages/ui/src/components/ForgeLoader.vue
@@ -1,17 +1,34 @@
 <template>
-  <div class="forge-loader">
-    <progress-spinner animation-duration=".75" :class="`text-${props.severity === undefined ? 'primary': props.severity }`"/>
+  <div :class="inLine ? '': 'forge-loader'">
+    <progress-spinner animation-duration=".75" :class="`text-${props.severity === undefined ? 'primary': props.severity }`" :pt="pt"/>
   </div>
 </template>
 
 <script setup lang="ts">
 import { Severity } from "../types/forge-types";
+import { computed } from "vue";
+import { ProgressSpinnerPassThroughOptions } from "primevue";
 
 export interface ForgeLoaderProps {
-  severity? : Severity
+  severity?: Severity,
+  inLine?: boolean,
 }
 
 const props = withDefaults(defineProps<ForgeLoaderProps>(), {
-  severity: 'primary'
+  severity: 'primary',
+  inLine: false
 })
+
+
+const pt = computed<ProgressSpinnerPassThroughOptions>(() => ({
+  spin: () => ({
+    class: [
+      'spinner-border',
+      {
+        'spinner-border-sm': props.inLine
+      }
+    ]
+  })
+}))
+
 </script>

--- a/packages/ui/src/components/ForgeProgressBar.vue
+++ b/packages/ui/src/components/ForgeProgressBar.vue
@@ -10,7 +10,7 @@ import { Severity } from "../types/forge-types";
 import { computed } from "vue";
 
 export interface ForgeProgressBarProps extends /* vue-ignore */ ProgressBarProps {
-  severity: Severity,
+  severity?: Severity,
   striped: boolean,
   animate: boolean,
   pixelWidth?: number

--- a/packages/ui/src/components/ForgeTile.vue
+++ b/packages/ui/src/components/ForgeTile.vue
@@ -22,7 +22,7 @@ import { Severity, BarPosition } from "../types/forge-types";
 import { computed } from "vue";
 
 export interface ForgeTileProps {
-  severity: Severity,
+  severity?: Severity,
   barPosition: BarPosition,
   clickable: boolean,
   selected?: boolean

--- a/packages/ui/src/components/file-uploader/ForgeFileUploader.vue
+++ b/packages/ui/src/components/file-uploader/ForgeFileUploader.vue
@@ -3,7 +3,7 @@
     <UploadButton v-bind="props" v-model="files" />
     <div v-if="showDragDropArea">
       <DragDropArea :max-file-input="props.maxFileInput" :max-file-size="props.maxFileSize" :accepted-file-types="props.acceptedFileTypes" v-model="files">
-      <span v-for="({ file }, index) in files">
+      <div v-for="({ file }, index) in files">
         <FileInfo
             :key="file.name"
             :class="index === files.length - 1 || files.length == 1 ? '' : 'border-bottom'"
@@ -13,7 +13,7 @@
             v-bind="props"
             @deleted="deleteFiles"
         />
-      </span>
+      </div>
       </DragDropArea>
       <FileInputInfo :max-file-size="props.maxFileSize" :max-file-input="maxFileInput" />
     </div>
@@ -24,7 +24,7 @@
 import UploadButton from "@/components/file-uploader/components/UploadButton.vue";
 import DragDropArea from "@/components/file-uploader/components/DragDropArea.vue";
 import FileInfo from "@/components/file-uploader/components/FileInfo.vue";
-import { ForgeFileStatus, ForgeFileType } from "../../types/forge-types";
+import { ForgeFileStatus, ForgeFileType } from "@/types/forge-types.ts";
 import { TypedSchema } from "vee-validate";
 import FileInputInfo from "@/components/file-uploader/components/FileInputInfo.vue";
 

--- a/packages/ui/src/components/file-uploader/components/DragDropArea.vue
+++ b/packages/ui/src/components/file-uploader/components/DragDropArea.vue
@@ -20,7 +20,7 @@
 import { Icon } from "@iconify/vue";
 import { addFiles } from '../utilities/utilities'
 import { computed, ref, defineModel } from "vue";
-import { ForgeFileStatus, ForgeFileType } from "../../../types/forge-types";
+import { ForgeFileStatus, ForgeFileType } from "@/types/forge-types.ts";
 
 interface DragDropAreaProps {
   maxFileInput: number,

--- a/packages/ui/src/components/file-uploader/components/FileInfo.vue
+++ b/packages/ui/src/components/file-uploader/components/FileInfo.vue
@@ -2,28 +2,31 @@
   <div class="py-4 px-3 d-flex" :data-cy="`file-info-${file.name}`">
     <div>
       <Image v-if="isImage(file.type)" id="thumbnail-image" image-class="image-file-thumbnail border"
-        :src="getThumbnailUrl(file)" :alt="file.name" width="75px" preview />
+             :src="getThumbnailUrl(file)" :alt="file.name" width="75px" preview />
       <Icon v-else id="file-earmark" icon="bi:file-earmark" color="black" width="75px" />
     </div>
     <div class="ms-3 d-flex flex-column">
       <div>
         <ForgeInlineEditor v-if="editableFileName" id="edit-file-name" v-model="fileName" :rules="customFileNameRules"
-          :name="file.name" :complete-action="updateFileName" />
+                           :name="file.name" :complete-action="updateFileName" />
         <span v-else id="file-name">{{ fileName }}</span>
       </div>
       <span class="text-black-50" id="file-type">File type: {{ file.type.split('/').pop() }}</span>
       <span class="text-black-50" id="file-size">File size: {{ formatFileSize(file.size) }}</span>
     </div>
 
-    <div class="ms-auto my-auto d-flex">
-      <UploadStatus :key="uploadStatus" :file-size="file.size" :upload-status="uploadStatus"
-        :bytes-uploaded="bytesUploaded" :max-file-size="maxFileSize" />
-      <Button link @click="uploadBlob"
-        v-if="uploadStatus === 'Not Uploaded' || uploadStatus === 'Failed' || uploadStatus === 'Duplicate' || uploadStatus === 'Aborted'">
-        <Icon
-          :icon="uploadStatus === 'Not Uploaded' || uploadStatus === 'Duplicate' ? 'bi:upload' : 'bi:arrow-clockwise'" />
+    <div class="ms-auto my-auto d-flex align-items-center gap-1">
+      <UploadStatus
+          :key="uploadStatus"
+          :file-size="file.size"
+          :upload-status="uploadStatus"
+          :bytes-uploaded="bytesUploaded"
+          :max-file-size="maxFileSize"
+      />
+      <Button link @click="uploadBlob" v-if="uploadStatus === 'Not Uploaded' || uploadStatus === 'Failed' || uploadStatus === 'Duplicate' || uploadStatus === 'Aborted'">
+        <Icon :icon="uploadStatus === 'Not Uploaded' || uploadStatus === 'Duplicate' ? 'bi:upload' : 'bi:arrow-clockwise'" />
       </Button>
-      <Button link @click="controller.value.abort()" v-if="uploadStatus === 'Uploading'">
+      <Button link @click="controller.abort()" v-if="uploadStatus === 'Uploading'">
         <Icon :icon="'bi:x-circle-fill'" />
       </Button>
       <Button link @click="deleteFileFromBlob" v-else id="delete-button">
@@ -50,7 +53,7 @@ import { TypedSchema } from "vee-validate";
 import { computed, ref, onMounted } from "vue";
 import UploadStatus from "@/components/file-uploader/components/UploadStatus.vue";
 import { BlockBlobClient, BlockBlobParallelUploadOptions } from "@azure/storage-blob";
-import { ForgeFileType } from "../../../types/forge-types";
+import { ForgeFileType } from "@/types/forge-types.ts";
 
 interface FileInfoProps {
   editableFileName: boolean,
@@ -102,7 +105,7 @@ const ensureFileNameHasCorrectExtension = () => {
   //correct wrong file extension
   else if (fileNameSections.length > 1) {
     if (lastWordInFileName !== fileExtensionFromMime) {
-      fileName.value =  fileName.value.replace(lastWordInFileName!, fileExtensionFromMime!);
+      fileName.value = fileName.value.replace(lastWordInFileName!, fileExtensionFromMime!);
     }
   }
 }
@@ -154,8 +157,8 @@ const deleteFileFromBlob = async () => {
   emits('deleted', file.value);
 }
 
-onMounted(() => {
-  if (autoUploadToBlob) {
+onMounted(() => {  
+  if (autoUploadToBlob && uploadStatus.value != 'Uploaded') {
     uploadBlob();
   }
 })

--- a/packages/ui/src/components/file-uploader/components/UploadStatus.vue
+++ b/packages/ui/src/components/file-uploader/components/UploadStatus.vue
@@ -1,15 +1,16 @@
 <template>
   <div class="d-flex align-items-center me-2">
-    <ForgeProgressBar v-if="uploadStatus === 'Uploading'" :pixelWidth="200" animate striped >{{ ((bytesUploaded / fileSize) * 100).toFixed(0)}}%</ForgeProgressBar>
-    <ForgeAlert id="upload-status-alert" v-if="uploadStatus !== 'Uploading' && uploadStatus !== 'Not Uploaded' && uploadStatus !== 'Uploaded' && uploadStatus !== 'Preparing'" :severity="alertSeverity" class="mb-0 w-75 ms-auto">{{ alertMessage }}</ForgeAlert>
+    <ForgeLoader v-if="props.uploadStatus === 'Uploading'" />
+    <ForgeAlert id="upload-status-alert" v-if="props.uploadStatus !== 'Uploading' && props.uploadStatus !== 'Not Uploaded' && props.uploadStatus !== 'Uploaded' && props.uploadStatus !== 'Preparing'"
+                :severity="alertSeverity" class="mb-0 w-75 ms-auto">{{ alertMessage }}
+    </ForgeAlert>
   </div>
 </template>
 
 <script setup lang="ts">
 import ForgeAlert from "@/components/ForgeAlert.vue";
-import ForgeProgressBar from "@/components/ForgeProgressBar.vue";
-import {computed} from 'vue'
-import {FileUploadStatus, formatFileSize} from "../utilities/utilities";
+import { computed } from 'vue'
+import { FileUploadStatus, formatFileSize } from "../utilities/utilities";
 
 interface UploadStatusProps {
   fileSize: number,
@@ -18,18 +19,18 @@ interface UploadStatusProps {
   uploadStatus: FileUploadStatus
 }
 
-const { fileSize, uploadStatus, bytesUploaded, maxFileSize} = defineProps<UploadStatusProps>()
+const props = defineProps<UploadStatusProps>()
 
-const alertSeverity = computed<string>(() => uploadStatus === 'Failed' || uploadStatus === 'InvalidFileType' || uploadStatus === 'InvalidFileSize' ? 'danger' : 'warning');
+const alertSeverity = computed<string>(() => props.uploadStatus === 'Failed' || props.uploadStatus === 'InvalidFileType' || props.uploadStatus === 'InvalidFileSize' ? 'danger' : 'warning');
 const alertMessage = computed<string>(() => {
-  switch (uploadStatus) {
+  switch (props.uploadStatus) {
     case 'InvalidFileType':
       return 'Upload Failed: File type is not accepted.'
     case 'InvalidFileSize':
-      return `Upload Failed: File size exceeds the ${formatFileSize(maxFileSize)} limit.`
+      return `Upload Failed: File size exceeds the ${formatFileSize(props.maxFileSize)} limit.`
     case 'Aborted':
       return 'Upload Failed: User cancelled.'
-    case 'DeleteFileFailed': 
+    case 'DeleteFileFailed':
       return 'Failed to delete: connection error, please try again';
     case 'Duplicate':
       return 'Upload Failed: A file with the same name has already been uploaded.';


### PR DESCRIPTION
Changes:
- Add `inLine` version of  `ForgeLoader`: a smaller version so it can be used for showing the uploading status of each file in the file uploader.
- `ForgeFileUploader`:
  - Fix functionality to stop file upload
  - Stop files from uploading again if new files are added
  - Replace broken progress bar with loading spinner
- Make severity optional for `ForgeTile`