### PR TITLE
Fix forge tree table expander on value change

### DIFF
--- a/.changeset/plain-worlds-count.md
+++ b/.changeset/plain-worlds-count.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui-3": patch
+---
+
+Fix full row expander on model value change not firing the setExpanderColumns, by adding a watch and firing the event

--- a/packages/ui/src/components/ForgeTreeTable.vue
+++ b/packages/ui/src/components/ForgeTreeTable.vue
@@ -252,6 +252,11 @@ watch(() => props.filters, (newValue) => {
   emits("update:tableContext", tableContext.value)
 }, {deep: true})
 
+
+watch(() => props.value, () => {
+  setExpanderColumns();
+})
+
 onMounted(() => {
   setExpanderColumns();
   emits("update:tableContext", tableContext.value);


### PR DESCRIPTION
Add a watch on the model value of the ForgeTreeTable to fire the method to set the expander column to be full width is set to do so.