### PR TITLE
give image preview toolbar a background so its always visible

### DIFF
--- a/.changeset/six-shirts-turn.md
+++ b/.changeset/six-shirts-turn.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui-3": patch
+---
+
+give image preview toolbar a background so its visible on light backgrounds

--- a/packages/ui/src/passthroughs/Image.pt.ts
+++ b/packages/ui/src/passthroughs/Image.pt.ts
@@ -4,7 +4,7 @@ export default {
     previewMask: 'preview-button',
     mask: "position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center mask",
     original: 'preview',
-    toolbar: 'position-absolute top-0 end-0 d-flex p-3 z-3',
+    toolbar: 'position-absolute top-0 end-0 d-flex p-3 z-3 bg-black',
     rotaterightbutton: 'btn text-white',
     rotateleftbutton: 'btn text-white',
     zoomoutbutton: 'btn text-white',


### PR DESCRIPTION
before: 
![image](https://github.com/user-attachments/assets/229db25b-4c5b-4c9d-99ec-dba05fccc527)
after: 
![image](https://github.com/user-attachments/assets/ed12c507-379a-4e9e-a021-d12621514ced)
