### PR TITLE
Update datepicker to set selected styling, disabled styling, and other month styling bases on passthrough props and extra styling

### DIFF
--- a/.changeset/lucky-dots-act.md
+++ b/.changeset/lucky-dots-act.md
@@ -1,0 +1,6 @@
+---
+"@3squared/forge-ui-3": minor
+---
+
+Update styling classes for the Datepicker component
+Add classes and passthrough options to check for disabled, dates, today and other months

--- a/apps/docs/components.d.ts
+++ b/apps/docs/components.d.ts
@@ -8,8 +8,6 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
-    ForgeConfirmPopup: typeof import('@3squared/forge-ui-3')['ForgeConfirmPopup']
-    ForgePageHeader: typeof import('@3squared/forge-ui-3')['ForgePageHeader']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
   }

--- a/packages/ui/src/components/ForgeDatepicker.vue
+++ b/packages/ui/src/components/ForgeDatepicker.vue
@@ -68,29 +68,31 @@ const clear = () => {
 const hasErrors = computed(() => errors.value.length > 0)
 
 const pt = computed(() => ({
-  dayCell: ({context} : DatePickerPassThroughMethodOptions) => ({
+  day: ({context, props, attrs} : DatePickerPassThroughMethodOptions) => {
+  return {
     class: [
-      `text-center date-${ props.severity === undefined ? 'primary' : props.severity }`,
+    "d-flex justify-content-center align-items-center",
       {
-        'cursor-pointer': !context.disabled,
-        'pe-none': context.disabled,
-        'text-white': context.selected
+          "text-white": context.selected && (!context.disabled || (context.disabled && context.otherMonth)),
+          "opacity-50": context.otherMonth,
+          "today": context.today,
+          "selected": context.selected && (!context.disabled || (context.disabled && context.otherMonth)),
+          "text-grey-300": (context.disabled && !context.otherMonth) || (props.minDate != undefined && new Date(context.date.year, context.date.month, context.date.day) < props.minDate) || (props.maxDate != undefined && new Date(context.date.year, context.date.month, context.date.day) > props.maxDate),
+          "fw-500": (context.disabled && !context.otherMonth) || (props.minDate != undefined && new Date(context.date.year, context.date.month, context.date.day) < props.minDate) || (props.maxDate != undefined && new Date(context.date.year, context.date.month, context.date.day) > props.maxDate),
       },
       // Severities
       {
-        'selected': context.selected && !context.disabled,
-        'text-primary': !context.selected && context.today && (props.severity === undefined || props.severity === 'primary'),
-        'text-brand': !context.selected && context.today && props.severity === 'brand',
-        'text-secondary': !context.selected && context.today && props.severity === 'secondary',
-        'text-success': !context.selected && context.today && props.severity === 'success',
-        'text-success-alternate': !context.selected && context.today && props.severity === 'success-alternate',
-        'text-warning': !context.selected && context.today && props.severity === 'warning',
-        'text-danger': !context.selected && context.today && props.severity === 'danger',
-        'text-info': !context.selected && context.today && props.severity === 'info'
+        'date-primary': attrs.severity === undefined || attrs.severity === 'primary',
+        'date-brand': attrs.severity === 'brand',
+        'date-secondary': attrs.severity === 'secondary',
+        'date-success': attrs.severity === 'success',
+        'date-success-alternate': attrs.severity === 'success-alternate',
+        'date-warning': attrs.severity === 'warning',
+        'date-danger': attrs.severity === 'danger',
+        'date-info': attrs.severity === 'info'
       }
     ]
-  }),
- 
+  }},
   dayLabel: ({ context } : DatePickerPassThroughMethodOptions) => ({
     class: [
       // Disabled States

--- a/packages/ui/src/components/ForgeDatepicker.vue
+++ b/packages/ui/src/components/ForgeDatepicker.vue
@@ -6,12 +6,12 @@
 
     <div class="position-relative w-100">
       <DatePicker v-bind="{...props, ...$attrs}" :pt="pt" v-model="model" @update:model-value="handleChange"
-                @blur="() => handleBlur" :input-class="{'datepicker-invalid': hasErrors}"/>
-      <Icon data-cy="icon" icon="bi:calendar4" v-show="props.showIcon"
-            class="position-absolute end-0 top-50 bottom-50 my-auto me-2 bg-white" 
+                @blur="() => handleBlur" :input-class="{'text-truncate':true, 'datepicker-invalid': hasErrors, 'pe-5': props.showIcon && props.modelValue, 'pe-4': (props.showIcon || props.modelValue) && !(props.showIcon && props.modelValue) }"/>
+      <Icon data-cy="icon" icon="bi:calendar4" v-show="props.showIcon && !props.inline"
+            class="position-absolute end-0 top-50 bottom-50 my-auto me-2 bg-white pe-none" 
             :class="`${ hasErrors ? 'text-danger-dark' : 'text-muted'}`"
       />
-      <Icon data-cy="icon" icon="bi:x" v-show="props.modelValue" @click="clear"
+      <Icon data-cy="icon" icon="bi:x" v-show="props.modelValue && !props.inline" @click="clear"
             class="position-absolute end-0 top-50 bottom-50 my-auto text-muted cursor-pointer bg-white"
             :class="props.showIcon ? 'datepicker-close-icon' : 'me-2'" />
     </div>
@@ -71,14 +71,21 @@ const pt = computed(() => ({
   day: ({context, props, attrs} : DatePickerPassThroughMethodOptions) => {
   return {
     class: [
-    "d-flex justify-content-center align-items-center",
+      "d-flex justify-content-center align-items-center",
       {
-          "text-white": context.selected && (!context.disabled || (context.disabled && context.otherMonth)),
-          "opacity-50": context.otherMonth,
-          "today": context.today,
-          "selected": context.selected && (!context.disabled || (context.disabled && context.otherMonth)),
-          "text-grey-300": (context.disabled && !context.otherMonth) || (props.minDate != undefined && new Date(context.date.year, context.date.month, context.date.day) < props.minDate) || (props.maxDate != undefined && new Date(context.date.year, context.date.month, context.date.day) > props.maxDate),
-          "fw-500": (context.disabled && !context.otherMonth) || (props.minDate != undefined && new Date(context.date.year, context.date.month, context.date.day) < props.minDate) || (props.maxDate != undefined && new Date(context.date.year, context.date.month, context.date.day) > props.maxDate),
+        //When using a range, a disabled date can be both selected and disabled. This logic fights that and also applies the class if a 
+        //date across a month boundary is also selected (not prime vue functionality for some reason)
+        "text-white": context.selected && (!context.disabled || (context.disabled && context.otherMonth)),
+        "opacity-50": context.otherMonth,
+        "today": context.today,
+        //When using a range, a disabled date can be both selected and disabled. This logic fights that and also applies the class if a 
+        //date across a month boundary is also selected (not prime vue functionality for some reason)
+        "selected": context.selected && (!context.disabled || (context.disabled && context.otherMonth)),
+        //This is used to show which dates should be shows as 'disabled'. The first part of logic is used to only (due to prime vue passing 
+        //disabled for otherMonth dates) show the disabled styling for current calendar dates. The second part of logic is used to set the 
+        //disabled state for dates out of the min/max date range, as they would also come through the context as disabled dates without knowing why
+        "text-grey-300": (context.disabled && !context.otherMonth) || (props.minDate != undefined && new Date(context.date.year, context.date.month, context.date.day) < props.minDate) || (props.maxDate != undefined && new Date(context.date.year, context.date.month, context.date.day) > props.maxDate),
+        "fw-500": (context.disabled && !context.otherMonth) || (props.minDate != undefined && new Date(context.date.year, context.date.month, context.date.day) < props.minDate) || (props.maxDate != undefined && new Date(context.date.year, context.date.month, context.date.day) > props.maxDate)
       },
       // Severities
       {

--- a/packages/ui/src/passthroughs/Datepicker.pt.ts
+++ b/packages/ui/src/passthroughs/Datepicker.pt.ts
@@ -51,7 +51,29 @@ export default {
       }
     }),
     title: "d-flex mx-auto",
-    day: "d-flex date-primary justify-content-center align-items-center",
+
+    dayCell: ({ context} : DatePickerPassThroughMethodOptions) => {
+      return {
+       class: [
+        {
+          "selected": context.selected
+        }
+        ]
+    }},
+    day: ({ context, props } : DatePickerPassThroughMethodOptions) => {
+      return {
+       class: [
+        "d-flex date date-primary justify-content-center align-items-center",
+        {
+          "text-white": context.selected && (!context.disabled || (context.disabled && context.otherMonth)),
+          "opacity-50": context.otherMonth,
+          "today": context.today,
+          "selected": context.selected && (!context.disabled || (context.disabled && context.otherMonth)),
+          "text-grey-300": (context.disabled && !context.otherMonth) || (props.minDate != undefined && new Date(context.date.year, context.date.month, context.date.day) < props.minDate) || (props.maxDate != undefined && new Date(context.date.year, context.date.month, context.date.day) > props.maxDate),
+          "fw-500": (context.disabled && !context.otherMonth) || (props.minDate != undefined && new Date(context.date.year, context.date.month, context.date.day) < props.minDate) || (props.maxDate != undefined && new Date(context.date.year, context.date.month, context.date.day) > props.maxDate),
+        }
+        ]
+    }},
     decade: "fw-bold",
     dayView: "datepicker-table",
     tableHeaderRow: "text-center",

--- a/packages/ui/src/passthroughs/Datepicker.pt.ts
+++ b/packages/ui/src/passthroughs/Datepicker.pt.ts
@@ -65,14 +65,20 @@ export default {
        class: [
         "d-flex date date-primary justify-content-center align-items-center",
         {
+          //When using a range, a disabled date can be both selected and disabled. This logic fights that and also applies the class if a 
+          //date across a month boundary is also selected (not prime vue functionality for some reason)
           "text-white": context.selected && (!context.disabled || (context.disabled && context.otherMonth)),
           "opacity-50": context.otherMonth,
           "today": context.today,
+          //When using a range, a disabled date can be both selected and disabled. This logic fights that and also applies the class if a 
+          //date across a month boundary is also selected (not prime vue functionality for some reason)
           "selected": context.selected && (!context.disabled || (context.disabled && context.otherMonth)),
+          //This is used to show which dates should be shows as 'disabled'. The first part of logic is used to only (due to prime vue passing 
+          //disabled for otherMonth dates) show the disabled styling for current calendar dates. The second part of logic is used to set the 
+          //disabled state for dates out of the min/max date range, as they would also come through the context as disabled dates without knowing why
           "text-grey-300": (context.disabled && !context.otherMonth) || (props.minDate != undefined && new Date(context.date.year, context.date.month, context.date.day) < props.minDate) || (props.maxDate != undefined && new Date(context.date.year, context.date.month, context.date.day) > props.maxDate),
-          "fw-500": (context.disabled && !context.otherMonth) || (props.minDate != undefined && new Date(context.date.year, context.date.month, context.date.day) < props.minDate) || (props.maxDate != undefined && new Date(context.date.year, context.date.month, context.date.day) > props.maxDate),
-        }
-        ]
+          "fw-500": (context.disabled && !context.otherMonth) || (props.minDate != undefined && new Date(context.date.year, context.date.month, context.date.day) < props.minDate) || (props.maxDate != undefined && new Date(context.date.year, context.date.month, context.date.day) > props.maxDate)
+        }]
     }},
     decade: "fw-bold",
     dayView: "datepicker-table",

--- a/packages/ui/src/styles/components/_datepicker.scss
+++ b/packages/ui/src/styles/components/_datepicker.scss
@@ -31,24 +31,40 @@
 
 @each $color, $value in $base-colors {
   .date-#{$color} {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
+    width: 32px !important;
+    height: 32px !important;
+    border-radius: 50% !important;
     
-    &.selected, &.selected:hover {
-      border-radius: 50%;
-      background-color: map-get($theme-colors, $color);
-    }
-    
-    &:hover {
+    &.today {
       @if($color == 'brand') {
         background-color: map-get($subtle-colors, '#{$color}-shade-1');
-        color: map-get($theme-colors, $color)
+        color: map-get($theme-colors, $color);
       } @else {
         background-color: map-get($subtle-colors, '#{$color}-subtle');
-        color: map-get($theme-colors, $color)
+        color: map-get($theme-colors, $color);
+      }    
+    }
+
+    &.selected, &.selected:hover {
+      background-color: map-get($theme-colors, $color);
+    }
+
+    &.text-grey-300.opacity-50 {
+      opacity: 1 !important;
+    }
+    
+    &:hover:not(.text-grey-300) {
+      @if($color == 'brand') {
+        background-color: map-get($subtle-colors, '#{$color}-shade-1');
+        color: map-get($theme-colors, $color) !important;
+      } @else {
+        background-color: map-get($subtle-colors, '#{$color}-subtle');
+        color: map-get($theme-colors, $color) !important;
       }
-      
+    }
+
+    &:hover:not(.text-grey-300, .opacity-50) {
+      cursor: pointer;
     }
   }
 }

--- a/packages/ui/src/styles/utilities/_utilities.scss
+++ b/packages/ui/src/styles/utilities/_utilities.scss
@@ -102,6 +102,12 @@ $sizes: (
   }
 }
 
+@each $color, $value in $grays {
+  .text-grey-#{$color} {
+    color: $value !important;
+  }
+}
+
 @each $font-weight, $value in $font-weights {
   .fw-#{$value} {
     font-weight: $value;


### PR DESCRIPTION
* Move the severity and selected classes for the selected cells to be on the day, not the day cell Add extra classes for setting the font weight and opacity of other months, and disabled dates or min/max dates
* Update to add a highlight class value for today