### PR TITLE
Fix Filter Header Select drop down not closing on clear

### DIFF
--- a/.changeset/common-cougars-swim.md
+++ b/.changeset/common-cougars-swim.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui-3": patch
+---
+
+Updated the click.prevent method to be click.stop to ensure the select popup closes when the clear button is clicked

--- a/packages/ui/src/components/table/ForgeFilterHeader.vue
+++ b/packages/ui/src/components/table/ForgeFilterHeader.vue
@@ -10,7 +10,7 @@
         <div class="d-flex w-100">
           <span :class="{ 'filter-placeholder': value === null }">{{ label(value, placeholder) }}</span>
           <Button v-if="showClearButton && modelValue !== null"
-                  @click.prevent="clear" size="small"
+                  @click.stop="clear" size="small"
                   class="bg-transparent border-0 ms-auto p-0 pe-1">
             <Icon icon="bi:x" width="1rem" height="1rem" class="text-black" />
           </Button>


### PR DESCRIPTION
Updated the click.prevent method to be click.stop to ensure the select popup closes when the clear button is clicked