### PR TITLE
Fix issue with file upload size being validated again the number of allowed files to upload when using the file input button

### DIFF
--- a/.changeset/weak-comics-joke.md
+++ b/.changeset/weak-comics-joke.md
@@ -1,0 +1,7 @@
+---
+"@3squared/forge-ui-3": patch
+---
+
+Fix issue with file upload size being validated again the number of allowed files to upload when using the file input button.
+
+Add the extra prop for the file size to be added to the Upload button and passed into the addFiles method to validate the file size correctly.

--- a/packages/ui/src/components/file-uploader/components/UploadButton.vue
+++ b/packages/ui/src/components/file-uploader/components/UploadButton.vue
@@ -38,6 +38,7 @@ import { Icon } from "@iconify/vue";
 interface FileUploaderButtonProps {
   acceptedFileTypes: ForgeFileType[],
   maxFileInput: number,
+  maxFileSize: number,
   showDragDropArea: boolean
 }
 
@@ -46,11 +47,11 @@ const acceptedFilesOverlay = ref()
 
 const toggleAcceptedFileTypesOverlay = (event: Event) => acceptedFilesOverlay.value.toggle(event)
 
-const { acceptedFileTypes, maxFileInput, showDragDropArea } = defineProps<FileUploaderButtonProps>()
+const { acceptedFileTypes, maxFileInput, maxFileSize, showDragDropArea } = defineProps<FileUploaderButtonProps>()
 
 const uploadDisabled = computed<boolean>(() => maxFileInput <= files.value.length)
 
 const addUploadedFiles = (filesToUpload : File[]) => {
-  files.value = addFiles(filesToUpload, files.value, acceptedFileTypes.map(ft => ft.fileType), maxFileInput)
+  files.value = addFiles(filesToUpload, files.value, acceptedFileTypes.map(ft => ft.fileType), maxFileSize)
 }
 </script>


### PR DESCRIPTION
Add the extra prop for the file size to be added to the Upload button and passed into the addFiles method to validate the file size correctly