### PR TITLE
Update passthroughs for Dropdown and Columns for small fixes

### DIFF
--- a/.changeset/calm-tools-stop.md
+++ b/.changeset/calm-tools-stop.md
@@ -1,0 +1,8 @@
+---
+"@3squared/forge-ui-3": patch
+---
+
+Update passthroughs for Dropdown and Columns for small fixes
+
+* Make dropdown disables use different cursor, fgor when disabled, so it doesn't look like you can click it
+* Add conditional logic on the sort badge icons, if the table is also sorted by the row group and an additional column, as this adds a 1 next to the single sortable field, and doesn't match the standard functionality

--- a/packages/ui/src/passthroughs/Column.pt.ts
+++ b/packages/ui/src/passthroughs/Column.pt.ts
@@ -2,8 +2,18 @@ import { ColumnPassThroughMethodOptions, ColumnProps } from "primevue/column";
 
 export default {
   column: {
-    pcSortBadge: {
-      root: 'ms-2 my-auto cursor-pointer'
+    pcSortBadge: (options: ColumnPassThroughMethodOptions) => {
+      return {
+        root: {
+          class: [
+            'ms-2 my-auto cursor-pointer',
+            {
+              // Remove the badge, if one of the (2) sort columns is the row grouping, as it looks like only one column is sortable. Will show numbers if not only 2 sort values
+              'd-none': options.parent.state.d_groupRowsSortMeta != undefined && options.parent.state.d_multiSortMeta != undefined && options.parent.state.d_multiSortMeta.length == 2 && options.parent.state.d_multiSortMeta.some((sort) => {return sort.field == options.parent.state.d_groupRowsSortMeta.field})
+            }
+          ]
+        }
+      }
     },
     headerCell: (options: any) => {
       return {

--- a/packages/ui/src/passthroughs/Dropdown.pt.ts
+++ b/packages/ui/src/passthroughs/Dropdown.pt.ts
@@ -5,9 +5,10 @@ export default {
     root: ({ props }: SelectPassThroughMethodOptions<any>) => {
       return {
         class: [
-          'form-select flex-1 d-flex cursor-pointer position-relative',
+          'form-select flex-1 d-flex position-relative',
           {
-            'disabled': props.disabled
+            'disabled': props.disabled,
+            'cursor-pointer ': !props.disabled
           }
         ]
       }


### PR DESCRIPTION
- Make dropdown disables use different cursor, for when disabled, so it doesn't look like you can click it
- Add conditional logic on the sort badge icons, if the table is also sorted by the row group and an additional column, as this adds a 1 next to the single sortable field, and doesn't match the standard functionality