### PR TITLE
Update the size of the confirmation modal

### DIFF
--- a/.changeset/nasty-mugs-warn.md
+++ b/.changeset/nasty-mugs-warn.md
@@ -1,0 +1,8 @@
+---
+"@3squared/forge-ui-3": minor
+---
+
+* Changed the size of the confirmation modal by removing the modal-sm class from the Dialog passthrough
+* Updated the forge form field to add a wrapper class around the input, also containing the validation text
+* Updated the styling classes on sadin forge form field, to remove the `flex-1` from the textarea, as this appears to stop it from being resized
+* Updated the logic for displaying sort orders when using the row group header in the data table, as some of the properties are not set when the table is empty 

--- a/packages/ui/src/components/ForgeFormField.vue
+++ b/packages/ui/src/components/ForgeFormField.vue
@@ -2,46 +2,46 @@
   <forge-checkbox :id="props.name" v-if="props.type === 'checkbox'" :label="props.fieldLabel" v-bind="$attrs"
                   :name="props.name" v-model="model" />
   <div class="d-flex flex-column w-100" v-else>
-    <div data-cy="input-wrapper" class="d-flex" :class="props.fieldLabelPosition === 'top' ? 'flex-column' : 'flex-row'">
+    <div data-cy="input-wrapper" class="d-flex flex--1" :class="props.fieldLabelPosition === 'top' ? 'flex-column' : 'flex-row'">
       <label :for="props.name" :class="props.fieldLabelPosition === 'top' ? 'mb-1' : ('me-2 ' + props.labelWidthClass)">
         {{ props.fieldLabel }} <span v-if="required" class="text-danger fw-600">*</span>
       </label>
-
-      <!-- Slot for Custom Inputs -->
-      <slot v-bind="{ modelValue: model, updateModel: handleChange, hasErrors  }">
-        <!-- Default Inputs (if no input is provided) -->
-        <InputNumber :id="props.name" v-if="props.type === 'number'" v-bind="$attrs" class="flex-1"
-                     :placeholder="props.placeholder" :input-class="{'is-invalid': hasErrors }" :class="{'is-invalid': hasErrors }"
-                     @input="change" v-model="model"
-        />
-        <Textarea :id="props.name" v-else-if="props.type === 'textarea'" v-bind="$attrs" class="flex-1"
-                  :placeholder="props.placeholder" :class="{'is-invalid': hasErrors }"
-                  v-model="model"
-                  @input="change" @blur="handleBlur"
-        />
-        <InputMask :id="props.name" v-else-if="props.type === 'mask'" v-bind="$attrs" class="flex-1"
-                   :placeholder="props.placeholder" :mask="props.mask" :class="{'is-invalid': hasErrors }"
-                   v-model="model" @complete="change" @blur="handleBlur"
-        />
-        <InputText :id="props.name" v-else-if="props.type === 'text'" v-bind="$attrs" class="flex-1"
-                   :placeholder="props.placeholder" :class="{'is-invalid': hasErrors }"
-                   v-model="model"
-                   @input="change" @blur="handleBlur"
-        />
-        <Select v-else-if="props.type === 'select'" v-bind="{...props,...$attrs}" v-model="model"
-                :class="{'is-invalid': hasErrors }" />
-        <MultiSelect v-else-if="props.type === 'multiselect'" v-bind="{...props,...$attrs}" v-model="model" 
-                     :class="{'is-invalid': hasErrors }" />
-        <ForgeMultiSelectPreview v-else-if="props.type === 'multiselect-preview'" v-bind="{...props,...$attrs}" v-model="model" 
-                                 :class="{'is-invalid': hasErrors }" />
-        <ForgeDatepicker v-else-if="props.type === 'datepicker'" v-bind="{...props,...$attrs}" v-model="model" 
-                         :class="{'is-invalid': hasErrors }" />
-      </slot>
-
+      <div class="flex--1" style="flex: 1 0 auto;">
+        <!-- Slot for Custom Inputs -->
+        <slot v-bind="{ modelValue: model, updateModel: handleChange, hasErrors  }">
+          <!-- Default Inputs (if no input is provided) -->
+          <InputNumber :id="props.name" v-if="props.type === 'number'" v-bind="$attrs" class="flex-1"
+                      :placeholder="props.placeholder" :input-class="{'is-invalid': hasErrors }" :class="{'is-invalid': hasErrors }"
+                      @input="change" v-model="model"
+          />
+          <Textarea :id="props.name" v-else-if="props.type === 'textarea'" v-bind="$attrs" class="w-100"
+                    :placeholder="props.placeholder" :class="{'is-invalid': hasErrors }"
+                    v-model="model"
+                    @input="change" @blur="handleBlur"
+          />
+          <InputMask :id="props.name" v-else-if="props.type === 'mask'" v-bind="$attrs" class="flex-1"
+                    :placeholder="props.placeholder" :mask="props.mask" :class="{'is-invalid': hasErrors }"
+                    v-model="model" @complete="change" @blur="handleBlur"
+          />
+          <InputText :id="props.name" v-else-if="props.type === 'text'" v-bind="$attrs" class="flex-1"
+                    :placeholder="props.placeholder" :class="{'is-invalid': hasErrors }"
+                    v-model="model"
+                    @input="change" @blur="handleBlur"
+          />
+          <Select v-else-if="props.type === 'select'" v-bind="{...props,...$attrs}" v-model="model"
+                  :class="{'is-invalid': hasErrors }" />
+          <MultiSelect v-else-if="props.type === 'multiselect'" v-bind="{...props,...$attrs}" v-model="model" 
+                      :class="{'is-invalid': hasErrors }" />
+          <ForgeMultiSelectPreview v-else-if="props.type === 'multiselect-preview'" v-bind="{...props,...$attrs}" v-model="model" 
+                                  :class="{'is-invalid': hasErrors }" />
+          <ForgeDatepicker v-else-if="props.type === 'datepicker'" v-bind="{...props,...$attrs}" v-model="model" 
+                          :class="{'is-invalid': hasErrors }" />
+        </slot>
+        
+        <!-- Validation Error Message -->
+        <small v-show="hasErrors && props.type !== 'multiselect' && props.type !== 'datepicker'" data-cy="error" class="invalid-feedback">{{ errorMessage }}</small>
+      </div>
     </div>
-    
-    <!-- Validation Error Message -->
-    <small v-show="hasErrors && props.type !== 'multiselect' && props.type !== 'datepicker'" data-cy="error" class="invalid-feedback">{{ errorMessage }}</small>
   </div>
 </template>
 

--- a/packages/ui/src/passthroughs/Column.pt.ts
+++ b/packages/ui/src/passthroughs/Column.pt.ts
@@ -9,8 +9,7 @@ export default {
             'ms-2 my-auto cursor-pointer',
             {
               // Remove the badge, if one of the (2) sort columns is the row grouping, as it looks like only one column is sortable. Will show numbers if not only 2 sort values
-              'd-none': options.parent.state.d_groupRowsSortMeta != undefined && options.parent.state.d_multiSortMeta != undefined && options.parent.state.d_multiSortMeta.length == 2 && options.parent.state.d_multiSortMeta.some((sort) => {return sort.field == options.parent.state.d_groupRowsSortMeta.field})
-            }
+              'd-none': options.parent.state.d_multiSortMeta != undefined && options.parent.state.d_multiSortMeta.length == 2 && options.parent.state.d_multiSortMeta.some((sort) => {return sort.field == options.parent.props.groupRowsBy})            }
           ]
         }
       }

--- a/packages/ui/src/passthroughs/Dialog.pt.ts
+++ b/packages/ui/src/passthroughs/Dialog.pt.ts
@@ -5,7 +5,7 @@ export default {
     root: ({parent}: DialogPassThroughMethodOptions<any>) => {
       if(parent.instance.$.type.name == 'ConfirmDialog')
         return {
-          class: ["modal modal-dialog modal-content h-auto m-0 modal-sm"]
+          class: ["modal modal-dialog modal-content h-auto m-0"]
         }
       return {}
     },


### PR DESCRIPTION
* Changed the size of the confirmation modal by removing the modal-sm class from the Dialog passthrough
* Updated the forge form field to add a wrapper class around the input, also containing the validation text
* Updated the styling classes on forge form field, to remove the `flex-1` from the textarea, as this appears to stop it from being resized
* Updated the logic for displaying sort orders when using the row group