### PR TITLE
Add in error override for Forge modal

### DIFF
--- a/.changeset/calm-rivers-lead.md
+++ b/.changeset/calm-rivers-lead.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui-3": minor
+---
+
+Add error override in forge modal

--- a/packages/ui/src/components/ForgeModal.vue
+++ b/packages/ui/src/components/ForgeModal.vue
@@ -8,7 +8,7 @@
     </template>
     <template v-for="(_, name) in $slots as unknown as DialogSlots" #[name]="slotProps">
       <template v-if="name == 'default'">
-        <div v-if="error.hasError" class="sticky-top py-3 error-bg" data-cy="error-wrapper">
+        <div v-if="error.hasError && !hideErrorBanner" class="sticky-top py-3 error-bg" data-cy="error-wrapper">
           <forge-alert severity="danger" data-cy="error" class="mb-0">
             <p :class="error.message.length > 0 ? 'my-auto' : 'mb-0'">{{ error.header }}</p>
             <ul v-if="error.message.length > 0">
@@ -63,6 +63,7 @@ export interface ForgeModalProps extends DialogProps {
   resetErrorOnClose?: boolean,
   maxHeight?: string | null,
   minHeight?: string | null
+  hideErrorBanner: boolean
 }
 
 const visible = defineModel<boolean>('visible', { required: true })
@@ -82,7 +83,8 @@ const props = withDefaults(defineProps<ForgeModalProps>(), {
   cancelButtonType: "button",
   submitButtonType: "button",
   size: "md",
-  resetErrorOnClose: true
+  resetErrorOnClose: true,
+  hideErrorBanner: false
 })
 
 const loading = ref(false)

--- a/packages/ui/tests/component/dialog/dialog.cy.ts
+++ b/packages/ui/tests/component/dialog/dialog.cy.ts
@@ -203,6 +203,23 @@ describe('<Dialog />', () => {
     });
   });
 
+    describe("Hide Errors", () => {
+    const errorMessage = "I am an Error!";
+
+    beforeEach(() => {
+      const onConfirm = () => {
+        throw new Error(errorMessage);
+      };
+      mountDialog({ onConfirm, hideErrorBanner: true });
+      cy.get(submitButtonId).click();
+    });
+
+    it("Hides Error alert if onConfirm throws an error and hideErrorBanner is true", () => {
+      cy.get('[data-cy="error"]')
+        .should("not.exist");
+    });
+  });
+
   it("Shows loading spinner whilst waiting for the function to complete", () => {
     // Arrange
     const onConfirm = () => new Promise((resolve) => setTimeout(resolve, 10000))


### PR DESCRIPTION
Add hideErrorBanner prop in forge modal to be able to hide unwanted errors