### PR TITLE
Add ability to be able to override the ms-api-version header in blob …

### DIFF
--- a/.changeset/stale-teams-wish.md
+++ b/.changeset/stale-teams-wish.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui-3": minor
+---
+
+Add in the ability to be able to override the sazure storage version ms-api-version header

--- a/packages/ui/src/components/file-uploader/ForgeFileUploader.vue
+++ b/packages/ui/src/components/file-uploader/ForgeFileUploader.vue
@@ -51,7 +51,8 @@ export interface ForgeFileUploaderProps {
   maxFileInput?: number,
   editableFileName?: boolean,
   autoUploadToBlob?: boolean,
-  maxFileWarning?: string
+  maxFileWarning?: string,
+  storageServiceVersionOverride?: string
 }
 
 const props = withDefaults(defineProps<ForgeFileUploaderProps>(), {


### PR DESCRIPTION
…storage requests

Add in method to create blob client with optional policy to override the ms-api-version if an override is provided