### PR TITLE
Feat: adjust alert to be warning and not error

### DIFF
--- a/.changeset/cuddly-houses-arrive.md
+++ b/.changeset/cuddly-houses-arrive.md
@@ -1,0 +1,6 @@
+---
+"@3squared/forge-ui-3": patch
+"forge-ui-3-styleguide": patch
+---
+
+change to file uploader banner to be a warning and not an error

--- a/packages/ui/src/components/file-uploader/ForgeFileUploader.vue
+++ b/packages/ui/src/components/file-uploader/ForgeFileUploader.vue
@@ -1,6 +1,6 @@
 <template>
   <div data-cy="file-uploader">
-    <ForgeAlert id="max-files-alert" v-if="files.length == maxFileInput && props.maxFileWarning != null" severity="danger">
+    <ForgeAlert id="max-files-alert" v-if="files.length == maxFileInput && props.maxFileWarning != null" severity="warn">
       {{maxFileWarning}}
     </ForgeAlert>
     <UploadButton v-bind="props" v-model="files" />


### PR DESCRIPTION
Changing the alert on maximum number of files uploaded to be a warning and not an error as it's not preventing a submission.